### PR TITLE
Fix DUSK base value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-consensus"
-version = "0.1.1-rc.1"
+version = "0.1.1-rc.2"
 edition = "2021"
 repository = "https://github.com/dusk-network/consensus"
 description = "An implementation of Succinct Attestation consensus protocol"

--- a/src/user/provisioners.rs
+++ b/src/user/provisioners.rs
@@ -11,7 +11,7 @@ use node_data::bls::PublicKey;
 use num_bigint::BigInt;
 use std::collections::BTreeMap;
 
-pub const DUSK: u64 = 100_000_000;
+pub const DUSK: u64 = 1_000_000_000;
 
 #[derive(Clone, Debug)]
 #[allow(unused)]

--- a/tests/sortition.rs
+++ b/tests/sortition.rs
@@ -22,7 +22,7 @@ fn test_deterministic_sortition_1() {
     p.update_eligibility_flag(cfg.round);
 
     assert_eq!(
-        vec![1, 3],
+        vec![1, 2, 1],
         Committee::new(PublicKey::default(), &mut p, cfg).get_occurrences()
     );
 }
@@ -35,7 +35,7 @@ fn test_deterministic_sortition_2() {
     let cfg = Config::new(Seed::from([3u8; 48]), 7777, 8, 45);
 
     let committee = Committee::new(PublicKey::default(), &mut p, cfg);
-    assert_eq!(vec![1, 3], committee.get_occurrences());
+    assert_eq!(vec![2, 2], committee.get_occurrences());
 }
 
 #[test]


### PR DESCRIPTION
Change the DUSK base value from 100 million to 1 billion. This brings the Rust implementation back in line with the Golang implementation. See the changes [here](https://github.com/dusk-network/dusk-blockchain/pull/1518/files)

Resolves #51